### PR TITLE
replace unsupported flag

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-qemu-system-i386 -curses -enable-kvm -hda ${1:-miniforth.img}
+qemu-system-i386 -display curses -enable-kvm -hda ${1:-miniforth.img}


### PR DESCRIPTION
The flag "-curses" was removed  in QEMU 7.10, and replaced with "-display curses".